### PR TITLE
Added icons for AppleTV (Swiftfin & Infuse), Roku & Finamp

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -123,9 +123,9 @@ export default function DashboardPage({
               deviceImage = `https://static.firecore.com/images/infuse/infuse-icon_3x.png`
               deviceColour = "bg-gradient-to-br from-[#444444] to-[#000000]"
           }
-          // FinAmp
+          // FinAmp - 10.9 use: ${url}/web/assets/img/devices/finamp.svg
           else if (element.Client == "Finamp") {
-              deviceImage = `${url}/web/assets/img/devices/finamp.svg`
+              deviceImage = `https://raw.githubusercontent.com/jellyfin/jellyfin-web/69053a131f1c01b6ce018795ade07fd6adeddb08/src/assets/img/devices/finamp.svg`
               deviceColour = "bg-gradient-to-br from-[#052249] to-[#AA5CC3]"
           }
           // Samsung TV
@@ -143,9 +143,9 @@ export default function DashboardPage({
             deviceImage = `${url}/web/assets/img/devices/playstation.svg`
             deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
           }
-          // Roku
+          // Roku - 10.9 use: ${url}/web/assets/img/devices/roku.svg
           else if (element.Client == "Jellyfin Roku") {
-            deviceImage = `${url}/web/assets/img/devices/roku.svg`
+            deviceImage = `https://raw.githubusercontent.com/jellyfin/jellyfin-web/69053a131f1c01b6ce018795ade07fd6adeddb08/src/assets/img/devices/roku.svg`
             deviceColour = "bg-gradient-to-br from-[#2D1E39] to-[#732EA9]"
           }
           // Fallback

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -114,7 +114,7 @@ export default function DashboardPage({
             deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
           }
           // Apple tvOS
-          else if (element.Client == "Jellyfin tvOS") {
+          else if ((element.Client == "Jellyfin tvOS") || (element.Client == "Jellyfin iOS")) {
               deviceImage = `${url}/web/assets/img/devices/apple.svg`
               deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
           }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -119,9 +119,9 @@ export default function DashboardPage({
               deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
           }
           // FinAmp
-          else if (element.Client?.includes("FinAmp")) {
+          else if (element.Client == "Finamp") {
               deviceImage = `${url}/web/assets/img/devices/finamp.svg`
-              deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
+              deviceColour = "bg-gradient-to-br from-[#052249] to-[#AA5CC3]"
           }
           // Samsung TV
           else if (element.DeviceName == "Samsung Smart TV" && (element.Client == "Jellyfin Web")) {
@@ -141,7 +141,7 @@ export default function DashboardPage({
           // Roku
           else if (element.DeviceName?.includes("Roku")) {
             deviceImage = `${url}/web/assets/img/devices/roku.svg`
-            deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
+            deviceColour = "bg-gradient-to-br from-[#2D1E39] to-[#732EA9]"
           }
           // Fallback
           else {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -144,7 +144,7 @@ export default function DashboardPage({
             deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
           }
           // Roku
-          else if (element.DeviceName?.includes("Roku")) {
+          else if (element.Client = "Jellyfin Roku") {
             deviceImage = `${url}/web/assets/img/devices/roku.svg`
             deviceColour = "bg-gradient-to-br from-[#2D1E39] to-[#732EA9]"
           }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -113,6 +113,16 @@ export default function DashboardPage({
             deviceImage = `${url}/web/assets/img/devices/apple.svg`
             deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
           }
+          // Apple tvOS
+          else if (element.Client == "Jellyfin tvOS") {
+              deviceImage = `${url}/web/assets/img/devices/apple.svg`
+              deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
+          }
+          // FinAmp
+          else if (element.Client?.includes("FinAmp")) {
+              deviceImage = `${url}/web/assets/img/devices/finamp.svg`
+              deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
+          }
           // Samsung TV
           else if (element.DeviceName == "Samsung Smart TV" && (element.Client == "Jellyfin Web")) {
             deviceImage = `${url}/web/assets/img/devices/samsungtv.svg`
@@ -126,6 +136,11 @@ export default function DashboardPage({
           // Playstation
           else if (element.DeviceName?.includes("Sony PS")) {
             deviceImage = `${url}/web/assets/img/devices/playstation.svg`
+            deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
+          }
+          // Roku
+          else if (element.DeviceName?.includes("Roku")) {
+            deviceImage = `${url}/web/assets/img/devices/roku.svg`
             deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
           }
           // Fallback

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -144,7 +144,7 @@ export default function DashboardPage({
             deviceColour = "bg-gradient-to-br from-[#1C6FB5] to-[#052249]"
           }
           // Roku
-          else if (element.Client = "Jellyfin Roku") {
+          else if (element.Client == "Jellyfin Roku") {
             deviceImage = `${url}/web/assets/img/devices/roku.svg`
             deviceColour = "bg-gradient-to-br from-[#2D1E39] to-[#732EA9]"
           }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -118,6 +118,11 @@ export default function DashboardPage({
               deviceImage = `${url}/web/assets/img/devices/apple.svg`
               deviceColour = "bg-gradient-to-br from-[#A7A7A7] to-[#4F4F4F]"
           }
+          // Infuse
+          else if (element.Client == "Infuse") {
+              deviceImage = `https://static.firecore.com/images/infuse/infuse-icon_3x.png`
+              deviceColour = "bg-gradient-to-br from-[#444444] to-[#000000]"
+          }
           // FinAmp
           else if (element.Client == "Finamp") {
               deviceImage = `${url}/web/assets/img/devices/finamp.svg`


### PR DESCRIPTION
Super small change. Just adding in icons for AppleTV (Swiftfin & Infuse) along with Roku & Finamp. Starting in 10.9, it looks like Roku and Finamp SVGs are going to be included with Jellyfin web but for now I am pulling from the Jellyfin-Web github repo. Infuse I am pulling the PNG from their website since this icon does not appear to be included in 10.9.

Let me know if there are any changes or if this isn't the best way to approach these changes!